### PR TITLE
Set SessionCreate on the plist used to install the service

### DIFF
--- a/lib/installers/Darwin.js
+++ b/lib/installers/Darwin.js
@@ -128,6 +128,8 @@ exports.install = function(name, options, callback) {
 	plistData["RunAtLoad"] = true;
 	plistData["StandardOutPath"] = path.join(logPath, 'stdout.log');
 	plistData["StandardErrorPath"] = path.join(logPath, 'stderr.log');
+	// Set SessionCreate to true so the service can access things like the login.keychain
+	plistData["SessionCreate"] = true;
 	
 	if (options.env) {
 		plistData["EnvironmentVariables"] = options.env;


### PR DESCRIPTION
Here is the update to the svcinstall node module needed to give a service the ability to modify the keycahin search list or even access a login.keychain from a daemon / launch agent.

vsoagent-installer obviously would then need to be updated to use the new version of svcinstall with this fix in place.
